### PR TITLE
Add MySQL MGR operator 8.4 image builds

### DIFF
--- a/images/community-operator/Dockerfile
+++ b/images/community-operator/Dockerfile
@@ -1,0 +1,40 @@
+ARG MGR_OPERATOR_REF=8.4.9-2.1.11-r1
+FROM alpine:3.22.2 AS downloader
+
+ARG MGR_OPERATOR_REF
+WORKDIR /tmp
+RUN wget -q "https://github.com/ksmartdata/mgr-operator/archive/${MGR_OPERATOR_REF}.zip" -O mgr-operator.zip && \
+    unzip -q mgr-operator.zip && \
+    mv mgr-operator-* mgr-operator-src
+
+FROM --platform=$TARGETPLATFORM python:3.13-slim AS python-deps
+
+WORKDIR /tmp
+COPY --from=downloader /tmp/mgr-operator-src/docker-deps/requirements.txt .
+RUN python -m pip install --no-cache-dir --target=/tmp/site-packages -r requirements.txt --no-deps
+
+FROM --platform=$TARGETPLATFORM container-registry.oracle.com/os/oraclelinux:9-slim
+
+ARG MYSQL_REPO_URL=https://repo.mysql.com
+ARG MYSQL_CONFIG_PKG=mysql84-community-release
+ARG MYSQL_SHELL_REPO=mysql-tools-8.4-lts-community
+ARG MYSQL_SHELL_VERSION=8.4.9
+
+RUN rpm -U "${MYSQL_REPO_URL}/${MYSQL_CONFIG_PKG}-el9.rpm" && \
+    printf "[main]\nip_resolve=4\ntimeout=30\nretries=3\ntsflags=nodocs\n" > /etc/dnf/dnf.conf && \
+    microdnf install --disablerepo="*" --enablerepo=ol9_baseos_latest --enablerepo=ol9_appstream --enablerepo="${MYSQL_SHELL_REPO}" -y glibc-langpack-en "mysql-shell-${MYSQL_SHELL_VERSION}" && \
+    rpm -e "${MYSQL_CONFIG_PKG}" && \
+    microdnf clean all
+
+RUN groupadd -g27 mysql && useradd -u27 -g27 mysql
+
+RUN mkdir /mysqlsh && chown 2 /mysqlsh
+
+COPY --from=python-deps /tmp/site-packages/ /usr/lib/mysqlsh/python-packages/
+COPY --from=downloader /tmp/mgr-operator-src/mysqloperator/ /usr/lib/mysqlsh/python-packages/mysqloperator/
+
+RUN sed -i "s/available_replicas=None,/available_replicas=0,/" /usr/lib/mysqlsh/python-packages/kubernetes/client/models/v1_stateful_set_status.py
+
+USER 2
+
+ENV HOME=/mysqlsh

--- a/images/mgr-operator/Dockerfile
+++ b/images/mgr-operator/Dockerfile
@@ -27,9 +27,4 @@ ARG BASE_VERSION
 ARG BASE_IMAGE_REPOSITORY
 COPY --from=downloader /tmp/mgr-operator-src/mysqloperator/ /usr/lib/mysqlsh/python-packages/mysqloperator/
 COPY --from=builder /usr/local/bin/diagnose /usr/local/bin/diagnose
-# 1.35.4.post1是为来修复在报429的情况下operator不重试的bug，因为mgr-operator因为依赖特定版本的python没有办法用新版本的kopf
-# 所以在特定版本的kopf上修改了kopf的代码来修复这个问题
-USER root
-RUN pip3 uninstall -y kopf && \
-    pip3 install kopf-retry-after==1.35.4.post1
 USER 2

--- a/images/mgr-operator/Dockerfile
+++ b/images/mgr-operator/Dockerfile
@@ -1,25 +1,31 @@
 ARG BASE_VERSION=8.3.0-2.1.2
+ARG BASE_IMAGE_REPOSITORY=ghcr.io/ksmartdata/community-operator
 FROM alpine:3.22.2 AS downloader
 
+ARG MGR_OPERATOR_REF=package
+ARG MYSQL_OPERATOR_EXTRA_IMAGE_REF=extra_image
 WORKDIR /tmp
-RUN wget -q https://github.com/ksmartdata/mgr-operator/archive/refs/heads/package.zip -O mgr-operator.zip && \
+RUN wget -q "https://github.com/ksmartdata/mgr-operator/archive/${MGR_OPERATOR_REF}.zip" -O mgr-operator.zip && \
     unzip -q mgr-operator.zip && \
-    wget -q https://github.com/ksmartdata/mysql-operator/archive/refs/heads/extra_image.zip -O extra_image.zip && \
-    unzip -q extra_image.zip
+    mv mgr-operator-* mgr-operator-src && \
+    wget -q "https://github.com/ksmartdata/mysql-operator/archive/${MYSQL_OPERATOR_EXTRA_IMAGE_REF}.zip" -O extra_image.zip && \
+    unzip -q extra_image.zip && \
+    mv mysql-operator-* mysql-operator-src
 
 FROM --platform=$TARGETPLATFORM golang:1.23.3-alpine AS builder
 USER root
 WORKDIR /mgr-diagnose
-COPY --from=downloader /tmp/mysql-operator-extra_image/images/mgr-diagnose/go.mod ./
-COPY --from=downloader /tmp/mysql-operator-extra_image/images/mgr-diagnose/go.sum ./
+COPY --from=downloader /tmp/mysql-operator-src/images/mgr-diagnose/go.mod ./
+COPY --from=downloader /tmp/mysql-operator-src/images/mgr-diagnose/go.sum ./
 RUN go mod download
 
-COPY --from=downloader /tmp/mysql-operator-extra_image/images/mgr-diagnose/ /mgr-diagnose/
+COPY --from=downloader /tmp/mysql-operator-src/images/mgr-diagnose/ /mgr-diagnose/
 RUN CGO_ENABLED=0 go build -trimpath -ldflags "-w -s" -o /usr/local/bin/diagnose daocloud.io/mcamel/mgr-diagnose
 
-FROM --platform=$TARGETPLATFORM ghcr.io/ksmartdata/community-operator:${BASE_VERSION}
+FROM --platform=$TARGETPLATFORM ${BASE_IMAGE_REPOSITORY}:${BASE_VERSION}
 ARG BASE_VERSION
-COPY --from=downloader /tmp/mgr-operator-package/mysqloperator/ /usr/lib/mysqlsh/python-packages/mysqloperator/
+ARG BASE_IMAGE_REPOSITORY
+COPY --from=downloader /tmp/mgr-operator-src/mysqloperator/ /usr/lib/mysqlsh/python-packages/mysqloperator/
 COPY --from=builder /usr/local/bin/diagnose /usr/local/bin/diagnose
 # 1.35.4.post1是为来修复在报429的情况下operator不重试的bug，因为mgr-operator因为依赖特定版本的python没有办法用新版本的kopf
 # 所以在特定版本的kopf上修改了kopf的代码来修复这个问题


### PR DESCRIPTION
## Summary

- add a `community-operator` image build for MySQL operator 8.4.9
- allow `mgr-operator` builds to download source from a branch or tag ref
- build `mgr-operator` from the new `community-operator:8.4.9-2.1.11` base

## Notes

- Oracle does not publish `community-operator:8.4.9-2.1.11`, so this repo now builds the base image directly.
- The 8.4 base uses `mysqlsh 8.4.9` and upstream Python deps.
- The old `kopf-retry-after==1.35.4.post1` runtime install was removed because it is incompatible with Python 3.13.

## Validation

- Built and pushed `ghcr.io/ksmartdata/community-operator:8.4.9-2.1.11`
- Built and pushed `ghcr.io/ksmartdata/mgr-operator:8.4.9-2.1.11-r1`
- Verified both images expose `mysqlsh 8.4.9`
- Verified both images publish `linux/amd64` and `linux/arm64` manifests

Successful runs:
- https://github.com/ksmartdata/docker-images/actions/runs/28931278135
- https://github.com/ksmartdata/docker-images/actions/runs/28933371245
