### PR TITLE
Add MySQL 8.4 sidecar image (official Percona XtraBackup 8.4 packages)

### DIFF
--- a/images/mysql-operator-sidecar-8.4/Dockerfile
+++ b/images/mysql-operator-sidecar-8.4/Dockerfile
@@ -13,10 +13,10 @@ FROM --platform=$TARGETPLATFORM golang:1.21 AS builder
 
 ARG OPERATOR_REF=extra_image
 
-WORKDIR /build
-RUN wget -nv -O src.zip https://github.com/ksmartdata/mysql-operator/archive/refs/heads/${OPERATOR_REF}.zip \
-    && unzip -q src.zip && rm src.zip
-WORKDIR /build/mysql-operator-${OPERATOR_REF}
+# git is bundled with the golang image (wget/unzip are not)
+RUN git clone --depth 1 --branch ${OPERATOR_REF} \
+      https://github.com/ksmartdata/mysql-operator.git /build/mysql-operator
+WORKDIR /build/mysql-operator
 RUN CGO_ENABLED=0 go build -o /mysql-operator-sidecar ./cmd/mysql-operator-sidecar
 
 # runtime: EL9 (matches Percona's own PXB 8.4 image base)

--- a/images/mysql-operator-sidecar-8.4/Dockerfile
+++ b/images/mysql-operator-sidecar-8.4/Dockerfile
@@ -22,8 +22,10 @@ RUN CGO_ENABLED=0 go build -o /mysql-operator-sidecar ./cmd/mysql-operator-sidec
 # runtime: EL9 (matches Percona's own PXB 8.4 image base)
 FROM --platform=$TARGETPLATFORM oraclelinux:9
 
-RUN groupadd -g 999 mysql \
-    && useradd -u 999 -r -g 999 -s /sbin/nologin -c "Default Application User" mysql
+# -o: uid/gid 999 must match the other sidecar images (the operator runs the
+# pod with this identity), but EL9 already assigns 999 to a system account
+RUN groupadd -o -g 999 mysql \
+    && useradd -o -u 999 -r -g 999 -s /sbin/nologin -c "Default Application User" mysql
 
 COPY rootfs/ /
 

--- a/images/mysql-operator-sidecar-8.4/Dockerfile
+++ b/images/mysql-operator-sidecar-8.4/Dockerfile
@@ -1,0 +1,47 @@
+###############################################################################
+#  Docker image for MySQL 8.4 sidecar containers
+#
+#  Unlike the 5.7/8.0 sidecar images (manually built bases, xtrabackup
+#  compiled from source), this image installs the official Percona
+#  XtraBackup 8.4 packages: the pxb-84-lts yum repo ships both x86_64 and
+#  aarch64 for EL9, so no source build is needed for multi-arch.
+#  xtrabackup 8.0 cannot back up MySQL 8.4 servers, hence the new image.
+###############################################################################
+
+# build mysql-operator-sidecar from the operator fork
+FROM --platform=$TARGETPLATFORM golang:1.21 AS builder
+
+ARG OPERATOR_REF=extra_image
+
+WORKDIR /build
+RUN wget -nv -O src.zip https://github.com/ksmartdata/mysql-operator/archive/refs/heads/${OPERATOR_REF}.zip \
+    && unzip -q src.zip && rm src.zip
+WORKDIR /build/mysql-operator-${OPERATOR_REF}
+RUN CGO_ENABLED=0 go build -o /mysql-operator-sidecar ./cmd/mysql-operator-sidecar
+
+# runtime: EL9 (matches Percona's own PXB 8.4 image base)
+FROM --platform=$TARGETPLATFORM oraclelinux:9
+
+RUN groupadd -g 999 mysql \
+    && useradd -u 999 -r -g 999 -s /sbin/nologin -c "Default Application User" mysql
+
+COPY rootfs/ /
+
+# percona-xtrabackup-84 provides xtrabackup, xbstream and xbcloud;
+# gzip is invoked by the sidecar backup/candidate streams
+RUN dnf install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm \
+    && percona-release enable pxb-84-lts release \
+    && dnf install -y percona-xtrabackup-84 gzip unzip \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+
+# rclone via the official arch-aware installer
+RUN curl -fsSL https://rclone.org/install.sh | bash \
+    && rclone version
+
+COPY --from=builder /mysql-operator-sidecar /usr/local/bin/mysql-operator-sidecar
+RUN chmod 755 /usr/local/bin/mysql-operator-sidecar /usr/local/bin/docker-entrypoint.sh \
+    && chown 999:999 /usr/local/bin/mysql-operator-sidecar
+
+USER mysql
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/images/mysql-operator-sidecar-8.4/Dockerfile
+++ b/images/mysql-operator-sidecar-8.4/Dockerfile
@@ -8,8 +8,10 @@
 #  xtrabackup 8.0 cannot back up MySQL 8.4 servers, hence the new image.
 ###############################################################################
 
-# build mysql-operator-sidecar from the operator fork
-FROM --platform=$TARGETPLATFORM golang:1.21 AS builder
+# build mysql-operator-sidecar from the operator fork; the Go version also
+# pins the stdlib compiled into the binary - keep it current or the trivy
+# CRITICAL gate rejects the image (the module itself builds fine on new Go)
+FROM --platform=$TARGETPLATFORM golang:1.26-bookworm AS builder
 
 ARG OPERATOR_REF=extra_image
 

--- a/images/mysql-operator-sidecar-8.4/Dockerfile
+++ b/images/mysql-operator-sidecar-8.4/Dockerfile
@@ -32,12 +32,25 @@ RUN groupadd -o -g 999 mysql \
 COPY rootfs/ /
 
 # percona-xtrabackup-84 provides xtrabackup, xbstream and xbcloud;
-# gzip is invoked by the sidecar backup/candidate streams
+# gzip is invoked by the sidecar backup/candidate streams;
+# perl-DBI/perl-DBD-mysql are the runtime of the percona-toolkit scripts below
 RUN dnf install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm \
     && percona-release enable pxb-84-lts release \
-    && dnf install -y percona-xtrabackup-84 gzip unzip \
+    && dnf install -y percona-xtrabackup-84 gzip unzip perl perl-DBI perl-DBD-mysql \
     && dnf clean all \
     && rm -rf /var/cache/dnf
+
+# pt-heartbeat / pt-kill: the operator runs both as extra pod containers off
+# this same sidecar image. Percona ships no aarch64 EL9 percona-toolkit rpm,
+# but these two tools are pure Perl scripts - take them from the pinned
+# release tarball instead of the arch-gated package
+ARG PERCONA_TOOLKIT_VERSION=v3.7.1
+RUN curl -fsSL https://github.com/percona/percona-toolkit/archive/refs/tags/${PERCONA_TOOLKIT_VERSION}.tar.gz \
+      | tar -xz -C /tmp \
+    && install -m 755 /tmp/percona-toolkit-*/bin/pt-heartbeat /tmp/percona-toolkit-*/bin/pt-kill /usr/local/bin/ \
+    && rm -rf /tmp/percona-toolkit-* \
+    && pt-heartbeat --version \
+    && pt-kill --version
 
 # rclone via the official arch-aware installer
 RUN curl -fsSL https://rclone.org/install.sh | bash \

--- a/images/mysql-operator-sidecar-8.4/rootfs/usr/local/bin/docker-entrypoint.sh
+++ b/images/mysql-operator-sidecar-8.4/rootfs/usr/local/bin/docker-entrypoint.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+set -e
+
+echo "Create Google Drive service-account.json file."
+echo "${GDRIVE_SERVICE_ACCOUNT}" > /tmp/gdrive-service-account.json
+
+echo "Create rclone.conf file."
+cat <<EOF > /tmp/rclone.conf
+[gd]
+type = drive
+scope = drive
+service_account_file = /tmp/gdrive-service-account.json
+client_id = ${GDRIVE_CLIENT_ID}
+root_folder_id = ${GDRIVE_ROOT_FOLDER_ID}
+impersonate = ${GDRIVE_IMPERSONATOR}
+
+[s3]
+type = s3
+env_auth = true
+provider = ${S3_PROVIDER:-"AWS"}
+access_key_id = ${AWS_ACCESS_KEY_ID}
+secret_access_key = ${AWS_SECRET_ACCESS_KEY:-$AWS_SECRET_KEY}
+region = ${AWS_REGION:-"us-east-1"}
+endpoint = ${S3_ENDPOINT}
+acl = ${AWS_ACL}
+storage_class = ${AWS_STORAGE_CLASS}
+session_token = ${AWS_SESSION_TOKEN}
+no_check_bucket = true
+
+[gs]
+type = google cloud storage
+project_number = ${GCS_PROJECT_ID}
+service_account_file = /tmp/google-credentials.json
+object_acl = ${GCS_OBJECT_ACL}
+bucket_acl = ${GCS_BUCKET_ACL}
+location =  ${GCS_LOCATION}
+storage_class = ${GCS_STORAGE_CLASS:-"MULTI_REGIONAL"}
+
+[http]
+type = http
+url = ${HTTP_URL}
+
+[azure]
+type = azureblob
+account = ${AZUREBLOB_ACCOUNT}
+key = ${AZUREBLOB_KEY}
+EOF
+
+if [[ -n "${GCS_SERVICE_ACCOUNT_JSON_KEY:-}" ]]; then 
+    echo "Create google-credentials.json file."
+    cat <<EOF > /tmp/google-credentials.json
+    ${GCS_SERVICE_ACCOUNT_JSON_KEY}
+EOF
+else 
+    touch /tmp/google-credentials.json
+fi
+
+SIDECAR_BIN=mysql-operator-sidecar
+VERBOSE="--debug"
+
+# exec command
+case "$1" in
+    clone-and-init)
+        shift 1
+        exec $SIDECAR_BIN $VERBOSE clone-and-init "$@"
+        ;;
+    config-and-serve)
+        shift 1
+        exec $SIDECAR_BIN $VERBOSE run "$@"
+        ;;
+    take-backup-to)
+        shift 1
+        exec $SIDECAR_BIN $VERBOSE take-backup-to "$@"
+        ;;
+    schedule-backup)
+        shift 1
+        exec $SIDECAR_BIN $VERBOSE schedule-backup "$@"
+        ;;
+    *)
+        echo "Usage: $0 {clone-and-init|config-and-serve|take-backup-to|schedule-backup}"
+        echo "Now runs your command."
+        echo "$@"
+
+        exec "$@"
+esac


### PR DESCRIPTION
## Goal

MySQL 8.4 support for the master-slave operator: **xtrabackup 8.0 cannot back up MySQL 8.4 servers**, so 8.4 clusters get a dedicated sidecar image. Operator-side selection logic: ksmartdata/mysql-operator#16.

## Design

Unlike the 5.7/8.0 sidecar images (manually built bases, xtrabackup compiled from source on CentOS 8 vault), this image installs the **official Percona `pxb-84-lts` EL9 packages** — verified that Percona ships both x86_64 and aarch64 (latest 8.4.0-6), so multi-arch needs no source build and stays reproducible:

- builder: `golang:1.21`, sidecar binary from `ksmartdata/mysql-operator` (`OPERATOR_REF` build-arg, default `extra_image`)
- runtime: `oraclelinux:9` (same base family as Percona's own PXB image), `percona-xtrabackup-84` (provides xtrabackup/xbstream/xbcloud) + gzip + rclone (official arch-aware installer)
- same conventions as the existing sidecars: mysql user 999, `docker-entrypoint.sh` from rootfs (apt/gpg leftovers dropped — EL9 uses the yum repo)

## Verification

- The repo's PR CI does a multi-platform test build for the changed image dir (amd64 + arm64).
- After merge: publish with the `build-push-images.yml` dispatch (`job=mysql-operator-sidecar-8.4`), then the operator's 8.4.9 E2E case will exercise the full clone/backup path against it.