### PR TITLE
ci: add OCI source/revision labels and document the sidecar operator-ref pin convention

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -60,6 +60,9 @@ jobs:
           push: true
           platforms: ${{ env.BUILD_PLATFORM }}
           tags: ${{ env.ONLINE_REGISTER }}/${{ inputs.job }}:${{ inputs.tag }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/ksmartdata/docker-images
+            org.opencontainers.image.revision=${{ github.sha }}
           cache-from: type=gha
           build-args: ${{ inputs.build-args }}
           cache-to: type=gha,mode=max

--- a/images/mysql-operator-sidecar-8.4/Dockerfile
+++ b/images/mysql-operator-sidecar-8.4/Dockerfile
@@ -13,6 +13,10 @@
 # CRITICAL gate rejects the image (the module itself builds fine on new Go)
 FROM --platform=$TARGETPLATFORM golang:1.26-bookworm AS builder
 
+# Release convention: tag the mysql-operator repo first (e.g. v0.8.0), then
+# dispatch the build with build-args OPERATOR_REF=<that tag> so the sidecar
+# binary is pinned to an exact commit (git clone --branch accepts tags).
+# The default only exists for ad-hoc builds and floats with the branch head.
 ARG OPERATOR_REF=extra_image
 
 # git is bundled with the golang image (wget/unzip are not)
@@ -55,6 +59,11 @@ RUN curl -fsSL https://github.com/percona/percona-toolkit/archive/refs/tags/${PE
 # rclone via the official arch-aware installer
 RUN curl -fsSL https://rclone.org/install.sh | bash \
     && rclone version
+
+# re-declared so the builder-stage ARG is visible here; records which
+# mysql-operator ref the embedded sidecar binary was built from
+ARG OPERATOR_REF=extra_image
+LABEL io.ksmartdata.operator-ref=${OPERATOR_REF}
 
 COPY --from=builder /mysql-operator-sidecar /usr/local/bin/mysql-operator-sidecar
 RUN chmod 755 /usr/local/bin/mysql-operator-sidecar /usr/local/bin/docker-entrypoint.sh \


### PR DESCRIPTION
## Why

`ghcr.io/ksmartdata/mysql-operator-sidecar-8.4:v0.8.0` was published with empty OCI labels, and its embedded sidecar binary is cloned from a floating branch (`extra_image`) at build time — so neither the docker-images commit nor the mysql-operator commit behind an image tag was traceable.

## What

- `build-push-images.yml` (common job): add OCI labels so every image records the docker-images commit it was built from:
  - `org.opencontainers.image.source=https://github.com/ksmartdata/docker-images`
  - `org.opencontainers.image.revision=${{ github.sha }}`
- `images/mysql-operator-sidecar-8.4/Dockerfile`:
  - add `LABEL io.ksmartdata.operator-ref=${OPERATOR_REF}` in the runtime stage, recording which mysql-operator ref the embedded sidecar binary was built from;
  - document the release convention: tag the mysql-operator repo first (e.g. [v0.8.0](https://github.com/ksmartdata/mysql-operator/releases/tag/v0.8.0)), then dispatch the build with `build-args: OPERATOR_REF=<that tag>` so the binary is pinned to an exact commit (`git clone --branch` accepts tags). The floating default only remains for ad-hoc builds.

The PR CI rebuild of the changed image directory is expected (Dockerfile touched).