### PR TITLE
enable fastjson safeMode for rocketmq broker/nameserver/controller/exporter

### DIFF
--- a/images/rocketmq-broker/Dockerfile
+++ b/images/rocketmq-broker/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM --platform=$TARGETPLATFORM openjdk:8-alpine
+FROM --platform=$TARGETPLATFORM bellsoft/liberica-openjdk-alpine-musl:8
 
 RUN apk add --no-cache bash gettext nmap-ncat openssl busybox-extras tzdata
 # set default timezone

--- a/images/rocketmq-broker/runbroker-customize.sh
+++ b/images/rocketmq-broker/runbroker-customize.sh
@@ -167,6 +167,7 @@ JAVA_OPT="${JAVA_OPT} -XX:MaxDirectMemorySize=${MaxDirectMemorySize}"
 JAVA_OPT="${JAVA_OPT} -XX:-UseLargePages -XX:-UseBiasedLocking"
 JAVA_OPT="${JAVA_OPT} -Djava.ext.dirs=${JAVA_HOME}/jre/lib/ext:${BASE_DIR}/lib"
 #JAVA_OPT="${JAVA_OPT} -Xdebug -Xrunjdwp:transport=dt_socket,address=9555,server=y,suspend=n"
+JAVA_OPT="${JAVA_OPT} -Dfastjson.parser.safeMode=true"
 JAVA_OPT="${JAVA_OPT} ${JAVA_OPT_EXT}"
 JAVA_OPT="${JAVA_OPT} -cp ${CLASSPATH}"
 

--- a/images/rocketmq-controller/Dockerfile
+++ b/images/rocketmq-controller/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM --platform=$TARGETPLATFORM openjdk:8-alpine
+FROM --platform=$TARGETPLATFORM bellsoft/liberica-openjdk-alpine-musl:8
 
 RUN apk add --no-cache bash gettext nmap-ncat openssl busybox-extras tzdata
 # set default timezone

--- a/images/rocketmq-controller/runserver-customize.sh
+++ b/images/rocketmq-controller/runserver-customize.sh
@@ -169,6 +169,7 @@ JAVA_OPT="${JAVA_OPT} -verbose:gc -Xloggc:/dev/shm/rmq_srv_gc.log -XX:+PrintGCDe
 JAVA_OPT="${JAVA_OPT} -XX:-OmitStackTraceInFastThrow"
 JAVA_OPT="${JAVA_OPT}  -XX:-UseLargePages"
 JAVA_OPT="${JAVA_OPT} -Djava.ext.dirs=${JAVA_HOME}/jre/lib/ext:${BASE_DIR}/lib"
+JAVA_OPT="${JAVA_OPT} -Dfastjson.parser.safeMode=true"
 JAVA_OPT="${JAVA_OPT} ${JAVA_OPT_EXT}"
 JAVA_OPT="${JAVA_OPT} -cp ${CLASSPATH}"
 

--- a/images/rocketmq-exporter/Dockerfile
+++ b/images/rocketmq-exporter/Dockerfile
@@ -8,7 +8,7 @@ RUN curl -Lo rocketmq-exporter.zip https://github.com/apache/rocketmq-exporter/a
 
 RUN unzip rocketmq-exporter.zip
 
-RUN cd rocketmq-exporter-${ROCKETMQ_EXPORTER_VERSION} && mvn clean package -Dmaven.test.skip=true
+RUN cd rocketmq-exporter-${ROCKETMQ_EXPORTER_VERSION} && mvn clean package -Dmaven.test.skip=true -Dtomcat.version=9.0.118
 
 FROM --platform=$TARGETPLATFORM eclipse-temurin:8-jre
 

--- a/images/rocketmq-exporter/Dockerfile
+++ b/images/rocketmq-exporter/Dockerfile
@@ -8,7 +8,7 @@ RUN curl -Lo rocketmq-exporter.zip https://github.com/apache/rocketmq-exporter/a
 
 RUN unzip rocketmq-exporter.zip
 
-RUN cd rocketmq-exporter-${ROCKETMQ_EXPORTER_VERSION} && mvn clean package -Dmaven.test.skip=truedocker
+RUN cd rocketmq-exporter-${ROCKETMQ_EXPORTER_VERSION} && mvn clean package -Dmaven.test.skip=true
 
 FROM --platform=$TARGETPLATFORM eclipse-temurin:8-jre
 
@@ -18,4 +18,4 @@ COPY --from=builder /rocketmq-exporter-*/target/*-SNAPSHOT-exec.jar /rocketmq-ex
 
 EXPOSE 5557
 
-ENTRYPOINT ["java","-jar","rocketmq-exporter.jar"]
+ENTRYPOINT ["java","-Dfastjson.parser.safeMode=true","-jar","rocketmq-exporter.jar"]

--- a/images/rocketmq-nameserver/Dockerfile
+++ b/images/rocketmq-nameserver/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM --platform=$TARGETPLATFORM openjdk:8-alpine
+FROM --platform=$TARGETPLATFORM bellsoft/liberica-openjdk-alpine-musl:8
 
 RUN apk add --no-cache bash gettext nmap-ncat openssl busybox-extras tzdata
 # set default timezone

--- a/images/rocketmq-nameserver/runserver-customize.sh
+++ b/images/rocketmq-nameserver/runserver-customize.sh
@@ -171,6 +171,7 @@ JAVA_OPT="${JAVA_OPT} -XX:-OmitStackTraceInFastThrow"
 JAVA_OPT="${JAVA_OPT}  -XX:-UseLargePages"
 JAVA_OPT="${JAVA_OPT} -Djava.ext.dirs=${JAVA_HOME}/jre/lib/ext:${BASE_DIR}/lib"
 #JAVA_OPT="${JAVA_OPT} -Xdebug -Xrunjdwp:transport=dt_socket,address=9555,server=y,suspend=n"
+JAVA_OPT="${JAVA_OPT} -Dfastjson.parser.safeMode=true"
 JAVA_OPT="${JAVA_OPT} ${JAVA_OPT_EXT}"
 JAVA_OPT="${JAVA_OPT} -cp ${CLASSPATH}"
 


### PR DESCRIPTION
## Background

fastjson 1.2.68~1.2.83 has a deserialization RCE (Sangfor advisory 2026-07-21, no CVE assigned, no upstream 1.x fix). RocketMQ 5.x ships fastjson 1.2.83 in its official binary release; the exporter build pulls in fastjson 1.2.69_noneautotype. RocketMQ does not use autoType so real-world exploitability is low, but scanners flag it. Enabling safeMode (`-Dfastjson.parser.safeMode=true`, supported since 1.2.68) fully disables autoType and is the recommended mitigation.

## Changes

- **rocketmq-broker / rocketmq-nameserver / rocketmq-controller**: add `JAVA_OPT="${JAVA_OPT} -Dfastjson.parser.safeMode=true"` in the customize startup scripts, placed **before** the `${JAVA_OPT_EXT}` line so users can still override it via the documented `JAVA_OPT_EXT` env.
- **rocketmq-exporter**: add `-Dfastjson.parser.safeMode=true` to the exec-form ENTRYPOINT (before `-jar`; exec form has no shell so an ENV-based approach would not work).
- **rocketmq-exporter**: fix the `-Dmaven.test.skip=truedocker` typo → `-Dmaven.test.skip=true` (tests were silently not being skipped).
- **base image swap (unblocks CI)**: `openjdk:8-alpine` has been removed from Docker Hub, so broker/nameserver/controller builds fail on main as well. Switched to `bellsoft/liberica-openjdk-alpine-musl:8` (JDK 8u502, Docker verified publisher, linux/amd64 + linux/arm64, keeps the apk build flow and standard JDK8 layout incl. `jre/lib/ext`).
- **exporter: bump tomcat-embed-core 9.0.74 → 9.0.118** via `-Dtomcat.version` build override: trivy gates on 3 CRITICALs (CVE-2026-41293 / CVE-2026-43512 / CVE-2026-43515) fixed in 9.0.118 (same 9.0.x line as managed by spring-boot-starter-parent 2.7.11).

## Release plan

After merge, new tags will be published via `build-push-images.yml`: broker/nameserver/controller `v5.3.3-3` + `v5.1.4-3`, exporter `v0.1.2`.